### PR TITLE
Add clarification to README about potential task dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ namespace :db do
 end
 ```
 
-Now, if we run `rake db:migrate`, our database table will be created. 
+But, if we run `rake db:migrate` now, we're going to hit an error.
 
 #### Task Dependency
 
@@ -148,7 +148,7 @@ task :migrate => :environment do
 ...
 ```
 
-This creates a *task dependency*. Since our `Student.create_table` code would require access to the `config/environment.rb` file (which is where the student class and database are loaded), we need to give our task access to this file. We can do so by defining yet another Rake task that we can tell to run before the `migrate` task is run. 
+This creates a *task dependency*. Since our `Student.create_table` code would require access to the `config/environment.rb` file (which is where the student class and database are loaded), we need to give our task access to this file. In order to do that, we need to define yet another Rake task that we can tell to run before the `migrate` task is run. 
 
 Let's check out that `environment` task:
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ task :environment do
 end
 ```
 
+After adding our environemnt task, running `rake db:migrate` should create our students table.
+
 ### `rake db:seed`
 
 Another task you will become familiar with is the `seed` task. This task is responsible for "seeding" our database with some dummy data. 


### PR DESCRIPTION
@jmburges, @cernanb, @aturkewi 

Had a student who was coding along here and hit a task dependency error. The fix for it is right below in the README, but there was no indication that running `rake db:migrate` at that point would throw an error. This fix should clarify that the migrate task won't work before the task's dependency is defined.

P.S. let me know if there's someone I should be @ mentioning for these PRs.