### PR TITLE
Add Gemfile.lock, not done in 611629c6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,10 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rack (2.0.3)
+    rack-test (0.8.2)
+      rack (>= 1.0, < 3)
+    rake (12.3.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -29,8 +33,10 @@ PLATFORMS
 
 DEPENDENCIES
   pry
+  rack-test
+  rake
   rspec
   sqlite3
 
 BUNDLED WITH
-   1.10.6
+   1.16.0


### PR DESCRIPTION
611629c6 updated the `Gemfile`, but not the
`Gemfile.lock`. Consequently testing between
branches is impaired since running the test suite
makes `Gemfile.lock` dirty.